### PR TITLE
三星i9100 不支持 display:-webkit-flex布局，应改用display:-webkit-box系列的写法

### DIFF
--- a/issues/android.md
+++ b/issues/android.md
@@ -1,2 +1,6 @@
 Andorid Issues
 ==============
+  <b><p>1. 三星I9100 （Android 4.0.4）不支持display:-webkit-flex这种写法的弹性布局，</p> 
+         <p>但支持display:-webkit-box这种写法的布局, </p>
+         <p>相关的属性也要相应修改，如-webkit-box-pack: center;</p>
+         </b>


### PR DESCRIPTION
三星i9100 不支持 display:-webkit-flex布局，应改用display:-webkit-box系列的写法
